### PR TITLE
chore: Add export-ignore gitattributes to mirror npmignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,26 @@
+.vscode         export-ignore
 .github         export-ignore
 .ocamlformat    export-ignore
+
+wasm-micro-runtime/.devcontainer                export-ignore
+wasm-micro-runtime/.github                      export-ignore
+wasm-micro-runtime/assembly-script              export-ignore
+wasm-micro-runtime/build-scripts/esp-idf        export-ignore
+wasm-micro-runtime/build-scripts/build_llvm.py  export-ignore
+wasm-micro-runtime/**/SConscript                export-ignore
+wasm-micro-runtime/**/SConscript_config         export-ignore
+wasm-micro-runtime/ci                           export-ignore
+wasm-micro-runtime/core/app-framework           export-ignore
+wasm-micro-runtime/core/app-mgr                 export-ignore
+wasm-micro-runtime/core/deps                    export-ignore
+wasm-micro-runtime/doc                          export-ignore
+wasm-micro-runtime/language-bindings            export-ignore
+wasm-micro-runtime/product-mini                 export-ignore
+wasm-micro-runtime/samples                      export-ignore
+wasm-micro-runtime/test-tools/**                export-ignore
+wasm-micro-runtime/tests                        export-ignore
+wasm-micro-runtime/wamr-compiler                export-ignore
+wasm-micro-runtime/wamr-sdk                     export-ignore
+wasm-micro-runtime/zephyr                       export-ignore
 
 *.wasm          binary


### PR DESCRIPTION
This adds `export-ignore` entries into the `.gitattributes` file that matches the npmignore. This is necessary because I remembered that our `npm publish` in CI uses the tarball created for opam too. This will ensure a smaller tarball all around.